### PR TITLE
Print chars

### DIFF
--- a/trash/Cargo.toml
+++ b/trash/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "trash"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/trash/src/main.rs
+++ b/trash/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let c = 'z';
+    let z: char = 'ℤ'; // with explicit type annotation
+    let heart_eyed_cat = '😻';  // can print emojis!!! uses ASCII
+
+    println!("{c}, {z}, {heart_eyed_cat}");
+}


### PR DESCRIPTION
Learned that Rust stores chars using ASCII representation.